### PR TITLE
User : JWT 인증/인가 필터 적용 후 회원가입 및 로그인 구현

### DIFF
--- a/src/main/java/com/example/baglemonster/common/config/PasswordConfig.java
+++ b/src/main/java/com/example/baglemonster/common/config/PasswordConfig.java
@@ -1,0 +1,13 @@
+package com.example.baglemonster.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class PasswordConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() { return new BCryptPasswordEncoder(); }
+}

--- a/src/main/java/com/example/baglemonster/common/config/WebSecurityConfig.java
+++ b/src/main/java/com/example/baglemonster/common/config/WebSecurityConfig.java
@@ -1,0 +1,70 @@
+package com.example.baglemonster.common.config;
+
+import com.example.baglemonster.security.JwtAuthenticationFilter;
+import com.example.baglemonster.security.JwtAuthorizationFilter;
+import com.example.baglemonster.security.JwtUtil;
+import com.example.baglemonster.security.UserDetailsServiceImpl;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@RequiredArgsConstructor
+@EnableWebSecurity  // Spring Security 지원을 가능하게 함
+@EnableMethodSecurity(securedEnabled = true)
+public class WebSecurityConfig {
+    private final JwtUtil jwtUtil;
+    private final UserDetailsServiceImpl userDetailsService;
+    private final AuthenticationConfiguration authenticationConfiguration;
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
+        return configuration.getAuthenticationManager();
+    }
+
+    @Bean
+    public JwtAuthenticationFilter jwtAuthenticationFilter() throws Exception {
+        JwtAuthenticationFilter filter = new JwtAuthenticationFilter(jwtUtil);
+        filter.setAuthenticationManager(authenticationManager(authenticationConfiguration));
+        return filter;
+    }
+
+    @Bean
+    public JwtAuthorizationFilter jwtAuthorizationFilter() {
+        return new JwtAuthorizationFilter(jwtUtil, userDetailsService);
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        // CSRF 설정
+        http.csrf(AbstractHttpConfigurer::disable);
+
+        // Session 방식 -> JWT 방식 설정 변경
+        http.sessionManagement(sessionManagement ->
+                sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+
+        http.authorizeHttpRequests(authorizeHttpRequests ->
+                authorizeHttpRequests
+                        .requestMatchers(HttpMethod.POST, "/api/users/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/stores/**").permitAll()
+                        .requestMatchers("/swagger-ui/**", "/v3/**").permitAll()
+                        .anyRequest().authenticated() // 그 외 모든 요청 인증처리
+        );
+
+        // 필터 관리
+        http.addFilterBefore(jwtAuthorizationFilter(), JwtAuthenticationFilter.class);
+        http.addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+}

--- a/src/main/java/com/example/baglemonster/common/dto/ApiResponseDto.java
+++ b/src/main/java/com/example/baglemonster/common/dto/ApiResponseDto.java
@@ -1,0 +1,14 @@
+package com.example.baglemonster.common.dto;
+
+import lombok.Getter;
+
+@Getter
+public class ApiResponseDto {
+    private int statusCode;
+    private String statusMessage;
+
+    public ApiResponseDto(int statusCode, String statusMessage) {
+        this.statusCode = statusCode;
+        this.statusMessage = statusMessage;
+    }
+}

--- a/src/main/java/com/example/baglemonster/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/baglemonster/security/JwtAuthenticationFilter.java
@@ -1,0 +1,75 @@
+package com.example.baglemonster.security;
+
+import com.example.baglemonster.common.dto.ApiResponseDto;
+import com.example.baglemonster.user.dto.LoginRequestDto;
+import com.example.baglemonster.user.entity.UserRoleEnum;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import java.io.IOException;
+
+@Slf4j(topic = "로그인 및 JWT 생성")
+public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilter {
+    private final JwtUtil jwtUtil;
+
+    public JwtAuthenticationFilter(JwtUtil jwtUtil) {
+        this.jwtUtil = jwtUtil;
+        setFilterProcessesUrl("/api/users/signin");
+    }
+
+    @Override
+    public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws AuthenticationException {
+        log.info("로그인 시도");
+
+        try {
+            LoginRequestDto requestDto = new ObjectMapper().readValue(request.getInputStream(), LoginRequestDto.class);
+
+            return getAuthenticationManager().authenticate(
+                    new UsernamePasswordAuthenticationToken(
+                            requestDto.getEmail(),
+                            requestDto.getPassword(),
+                            null
+                    )
+            );
+        } catch (IOException e) {
+            log.error(e.getMessage());
+            throw new RuntimeException(e.getMessage());
+        }
+    }
+
+    @Override
+    protected void successfulAuthentication (HttpServletRequest request, HttpServletResponse response, FilterChain chain, Authentication authResult) throws IOException, ServletException {
+        log.info("로그인 성공 및 JWT 생성");
+        String email = ((UserDetailsImpl) authResult.getPrincipal()).getEmail();
+        UserRoleEnum role = ((UserDetailsImpl) authResult.getPrincipal()).getUser().getRole();
+
+        String token = jwtUtil.createToken(email, role);
+        response.addHeader(JwtUtil.AUTHORIZATION_HEADER, token);
+
+        response.setStatus(200);
+        response.setContentType("application/json");
+        String result = new ObjectMapper().writeValueAsString(new ApiResponseDto(HttpStatus.OK.value(), "Login Success"));
+
+        response.getOutputStream().print(result);
+    }
+
+    @Override
+    protected void unsuccessfulAuthentication (HttpServletRequest request, HttpServletResponse response, AuthenticationException failed) throws IOException, ServletException {
+        log.info("로그인 실패");
+
+        response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+        response.setContentType("application/json");
+        String result = new ObjectMapper().writeValueAsString(new ApiResponseDto(HttpStatus.BAD_REQUEST.value(), "Login Failed"));
+
+        response.getOutputStream().print(result);
+    }
+}

--- a/src/main/java/com/example/baglemonster/security/JwtAuthorizationFilter.java
+++ b/src/main/java/com/example/baglemonster/security/JwtAuthorizationFilter.java
@@ -1,0 +1,88 @@
+package com.example.baglemonster.security;
+
+import com.example.baglemonster.common.dto.ApiResponseDto;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Slf4j(topic = "JWT 검증 및 인가")
+public class JwtAuthorizationFilter extends OncePerRequestFilter {
+
+    private final JwtUtil jwtUtil;
+    private final UserDetailsServiceImpl userDetailsService;
+
+    public JwtAuthorizationFilter(JwtUtil jwtUtil, UserDetailsServiceImpl userDetailsService) {
+        this.jwtUtil = jwtUtil;
+        this.userDetailsService = userDetailsService;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest req, HttpServletResponse res, FilterChain filterChain) throws ServletException, IOException {
+        // Header에서 jwt 토큰 받아오기
+        String tokenValue = jwtUtil.getTokenFromRequest(req);
+
+        if (StringUtils.hasText(tokenValue)) {
+
+            if (!jwtUtil.validateToken(tokenValue)) {
+                res.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+                res.setContentType("application/json");
+                String result = new ObjectMapper().writeValueAsString(new ApiResponseDto(HttpStatus.BAD_REQUEST.value(), "INVALID_TOKEN"));
+
+                res.getOutputStream().print(result);
+                return;
+            }
+
+            Claims info;
+            try {
+                info = jwtUtil.getUserInfoFromToken(tokenValue);
+            } catch (Exception e) {
+                // JWT 검증에 실패한 경우 처리
+                res.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+                res.setContentType("application/json");
+                String result = new ObjectMapper().writeValueAsString(new ApiResponseDto(HttpStatus.BAD_REQUEST.value(), "INVALID_TOKEN"));
+
+                res.getOutputStream().print(result);
+                return;
+            }
+
+            try {
+                setAuthentication(info.getSubject());
+            } catch (Exception e) {
+                // 인증 처리에 실패한 경우 처리
+                log.error(e.getMessage());
+                return;
+            }
+        }
+
+        filterChain.doFilter(req, res);
+    }
+
+    // 인증 처리
+    public void setAuthentication(String email) {
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+        Authentication authentication = createAuthentication(email);
+        context.setAuthentication(authentication);
+
+        SecurityContextHolder.setContext(context);
+    }
+
+    // 인증 객체 생성
+    private Authentication createAuthentication(String email) {
+        UserDetails userDetails = userDetailsService.loadUserByUsername(email);
+        return new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+    }
+}

--- a/src/main/java/com/example/baglemonster/security/JwtUtil.java
+++ b/src/main/java/com/example/baglemonster/security/JwtUtil.java
@@ -1,0 +1,90 @@
+package com.example.baglemonster.security;
+
+import com.example.baglemonster.user.entity.UserRoleEnum;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import jakarta.servlet.http.HttpServletRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import java.security.Key;
+import java.util.Base64;
+import java.util.Date;
+
+@Component
+public class JwtUtil {
+    // Header key 값
+    public static final String AUTHORIZATION_HEADER = "Authorization";
+    // 사용자 권한의 key 값
+    public static final String AUTHORIZATION_KEY = "auth";
+    // token 식별자
+    public static final String BEARER_PREFIX = "Bearer ";
+    // 토큰 만료시간
+    private static final long TOKEN_TIME = 30 * 60 * 1000L; // 30분
+    // Base64로 인코딩한 secret key
+    @Value("${jwt.secret.key}")
+    private String secretKey;
+
+    private Key key;
+    private static final SignatureAlgorithm signatureAlgorithm = SignatureAlgorithm.HS256;
+
+    // 로그 설정
+    public static final Logger logger = LoggerFactory.getLogger("JWT 관련 로그");
+
+    @PostConstruct
+    public void init() {
+        byte[] bytes = Base64.getDecoder().decode(secretKey);
+        key = Keys.hmacShaKeyFor(bytes);
+    }
+
+    // JWT 생성
+    public String createToken(String email, UserRoleEnum role) {
+        Date date = new Date();
+
+        return BEARER_PREFIX +
+                Jwts.builder()
+                        .setSubject(email) // 사용자 식별자값(ID), 기존의 username에서 email로 변경
+                        .claim(AUTHORIZATION_KEY, role) // 사용자 권한
+                        .setExpiration(new Date(date.getTime() + TOKEN_TIME)) // 만료 시간
+                        .setIssuedAt(date) // 발급일
+                        .signWith(key, signatureAlgorithm) // 암호화 알고리즘
+                        .compact();
+    }
+
+    // HttpServletRequest 에서 Header Value : JWT 가져오기
+    public String getTokenFromRequest(HttpServletRequest req) {
+        String bearerToken = req.getHeader(AUTHORIZATION_HEADER);
+        if(StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
+            return bearerToken.substring(BEARER_PREFIX.length());
+        }
+
+        return null;
+    }
+
+    // 토큰 검증
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+            return true;
+        } catch (SecurityException | MalformedJwtException e) {
+            logger.error("Invalid JWT signature, 유효하지 않은 JWT 서명입니다.");
+        } catch (ExpiredJwtException e) {
+            logger.error("Expired JWT token, 만료된 JWT 토큰입니다.");
+        } catch (UnsupportedJwtException e) {
+            logger.error("Unsupported JWT token, 지원되지 않는 JWT 토큰입니다.");
+        } catch (IllegalArgumentException e) {
+            logger.error("JWT claims is empty, 잘못된 JWT 토큰입니다.");
+        }
+
+        return false;
+    }
+
+    // 토큰에서 사용자 정보 가져오기
+    public Claims getUserInfoFromToken(String token) {
+        return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody();
+    }
+}

--- a/src/main/java/com/example/baglemonster/security/UserDetailsImpl.java
+++ b/src/main/java/com/example/baglemonster/security/UserDetailsImpl.java
@@ -1,0 +1,69 @@
+package com.example.baglemonster.security;
+
+import com.example.baglemonster.user.entity.User;
+import com.example.baglemonster.user.entity.UserRoleEnum;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+public class UserDetailsImpl implements UserDetails {
+
+    private final User user;
+
+    public UserDetailsImpl(User user) {
+        this.user = user;
+    }
+
+    public User getUser() {
+        return user;
+    }
+
+    public String getEmail() {
+        return user.getEmail();
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        UserRoleEnum role = user.getRole();
+        String authority = role.getAuthority();
+
+        SimpleGrantedAuthority simpleGrantedAuthority = new SimpleGrantedAuthority(authority);
+        Collection<GrantedAuthority> authorities = new ArrayList<>();
+        authorities.add(simpleGrantedAuthority);
+
+        return authorities;
+    }
+
+    @Override
+    public String getPassword() {
+        return user.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getName();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/main/java/com/example/baglemonster/security/UserDetailsServiceImpl.java
+++ b/src/main/java/com/example/baglemonster/security/UserDetailsServiceImpl.java
@@ -1,0 +1,25 @@
+package com.example.baglemonster.security;
+
+import com.example.baglemonster.user.entity.User;
+import com.example.baglemonster.user.repository.UserRepository;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+public class UserDetailsServiceImpl implements UserDetailsService {
+    private final UserRepository userRepository;
+
+    public UserDetailsServiceImpl(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new UsernameNotFoundException("Not found " + email));
+
+        return new UserDetailsImpl(user);
+    }
+}

--- a/src/main/java/com/example/baglemonster/user/controller/UserController.java
+++ b/src/main/java/com/example/baglemonster/user/controller/UserController.java
@@ -3,6 +3,7 @@ package com.example.baglemonster.user.controller;
 import com.example.baglemonster.common.dto.ApiResponseDto;
 import com.example.baglemonster.user.dto.LoginRequestDto;
 import com.example.baglemonster.user.dto.SignupRequestDto;
+import com.example.baglemonster.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/example/baglemonster/user/controller/UserController.java
+++ b/src/main/java/com/example/baglemonster/user/controller/UserController.java
@@ -1,0 +1,38 @@
+package com.example.baglemonster.user.controller;
+
+import com.example.baglemonster.common.dto.ApiResponseDto;
+import com.example.baglemonster.user.dto.LoginRequestDto;
+import com.example.baglemonster.user.dto.SignupRequestDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+@Tag(name = "사용자 API", description = "사용자의 동작과 관련된 API 정보를 담고 있습니다.")
+public class UserController {
+
+    private final UserService userService;
+
+    @Operation(summary = "회원가입")
+    @PostMapping("/users/signup")
+    public ResponseEntity<ApiResponseDto> signup(@Validated @RequestBody SignupRequestDto signupRequestDto) {
+        userService.signup(signupRequestDto);
+        return ResponseEntity.ok().body(new ApiResponseDto(HttpStatus.OK.value(), "회원가입에 성공하셨습니다."));
+    }
+
+    @Operation(summary = "로그인")
+    @PostMapping("/users/signin")
+    public ResponseEntity<ApiResponseDto> signin(@RequestBody LoginRequestDto loginRequestDto) {
+        // 실제 로그인은 JWT 인증 필터에서 진행되며, 이 메서드는 Swagger에서 로그인 동작을 확인하기 위해 제작되었습니다.
+        return ResponseEntity.ok().body(new ApiResponseDto(HttpStatus.OK.value(), "로그인에 성공하셨습니다."));
+    }
+}

--- a/src/main/java/com/example/baglemonster/user/controller/UserService.java
+++ b/src/main/java/com/example/baglemonster/user/controller/UserService.java
@@ -1,0 +1,31 @@
+package com.example.baglemonster.user.controller;
+
+import com.example.baglemonster.user.dto.SignupRequestDto;
+import com.example.baglemonster.user.entity.User;
+import com.example.baglemonster.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    @Transactional
+    public void signup(SignupRequestDto signupRequestDto) {
+
+    }
+
+    private void checkDuplicateEmail(String email) {
+        if (userRepository.existsByEmail(email)) {
+            throw new IllegalStateException("이미 존재하는 이메일입니다.");
+        }
+    }
+
+    private User findUserById(Long id) {
+        return userRepository.findById(id).orElseThrow(
+                () -> new IllegalStateException("존재하지 않는 회원입니다."));
+    }
+}

--- a/src/main/java/com/example/baglemonster/user/dto/LoginRequestDto.java
+++ b/src/main/java/com/example/baglemonster/user/dto/LoginRequestDto.java
@@ -1,0 +1,11 @@
+package com.example.baglemonster.user.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class LoginRequestDto {
+    private String email;
+    private String password;
+}

--- a/src/main/java/com/example/baglemonster/user/dto/SignupRequestDto.java
+++ b/src/main/java/com/example/baglemonster/user/dto/SignupRequestDto.java
@@ -2,7 +2,6 @@ package com.example.baglemonster.user.dto;
 
 import com.example.baglemonster.user.entity.User;
 import com.example.baglemonster.user.entity.UserRoleEnum;
-import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import lombok.*;
@@ -16,7 +15,8 @@ public class SignupRequestDto {
     private String name;
 
     @NotBlank
-    @Email
+    @Pattern(regexp = "^[a-zA-Z0-9]+(.[_a-z0-9-]+)*@(?:\\w+\\.)+\\w+$",
+            message = "이메일은 영문자 및 숫자로 시작하여 중간에 @를 포함하고 2~3자의 최상위 도메인으로 끝나야 합니다.")
     private String email;
 
     @NotBlank

--- a/src/main/java/com/example/baglemonster/user/dto/SignupRequestDto.java
+++ b/src/main/java/com/example/baglemonster/user/dto/SignupRequestDto.java
@@ -1,0 +1,38 @@
+package com.example.baglemonster.user.dto;
+
+import com.example.baglemonster.user.entity.User;
+import com.example.baglemonster.user.entity.UserRoleEnum;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.*;
+
+@Builder
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class SignupRequestDto {
+    @NotBlank
+    private String name;
+
+    @NotBlank
+    @Email
+    private String email;
+
+    @NotBlank
+    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*#?&])[A-Za-z\\d@$!%*#?&]{8,}$",
+            message = "비밀번호는 영문자/숫자/특수문자 포함 8자리 이상이어야 합니다.")
+    private String password;
+
+    private String phone;
+
+    public User toEntity(String encodedPassword, UserRoleEnum role) {
+        return User.builder()
+                .name(name)
+                .email(email)
+                .password(encodedPassword)
+                .role(role)
+                .phone(phone)
+                .build();
+    }
+}

--- a/src/main/java/com/example/baglemonster/user/entity/User.java
+++ b/src/main/java/com/example/baglemonster/user/entity/User.java
@@ -1,0 +1,26 @@
+package com.example.baglemonster.user.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Builder
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Table(name="users")
+public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    private String email;
+
+    private String password;
+
+    private String phone;
+
+    private UserRoleEnum role;
+}

--- a/src/main/java/com/example/baglemonster/user/entity/UserRoleEnum.java
+++ b/src/main/java/com/example/baglemonster/user/entity/UserRoleEnum.java
@@ -1,0 +1,23 @@
+package com.example.baglemonster.user.entity;
+
+public enum UserRoleEnum {
+    USER(Authority.USER),
+    STORE(Authority.STORE),
+    ADMIN(Authority.ADMIN);
+
+    private final String authority;
+
+    UserRoleEnum(String authoirty) {
+        this.authority = authoirty;
+    }
+
+    public String getAuthority() { return this.authority; }
+
+    private static class Authority {
+        public static final String USER = "USER";
+
+        public static final String STORE = "STORE";
+
+        public static final String ADMIN = "ADMIN";
+    }
+}

--- a/src/main/java/com/example/baglemonster/user/repository/UserRepository.java
+++ b/src/main/java/com/example/baglemonster/user/repository/UserRepository.java
@@ -1,0 +1,12 @@
+package com.example.baglemonster.user.repository;
+
+import com.example.baglemonster.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByEmail(String email);
+
+    boolean existsByEmail(String email);
+}

--- a/src/main/java/com/example/baglemonster/user/service/UserService.java
+++ b/src/main/java/com/example/baglemonster/user/service/UserService.java
@@ -1,9 +1,10 @@
-package com.example.baglemonster.user.controller;
+package com.example.baglemonster.user.service;
 
 import com.example.baglemonster.user.dto.SignupRequestDto;
-import com.example.baglemonster.user.entity.User;
+import com.example.baglemonster.user.entity.UserRoleEnum;
 import com.example.baglemonster.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -12,20 +13,20 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserService {
 
     private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
 
     @Transactional
-    public void signup(SignupRequestDto signupRequestDto) {
+    public void signup(SignupRequestDto requestDto) {
+        String password = passwordEncoder.encode(requestDto.getPassword());
 
+        checkDuplicateEmail(requestDto.getEmail());
+
+        userRepository.save(requestDto.toEntity(password, UserRoleEnum.USER));
     }
 
     private void checkDuplicateEmail(String email) {
         if (userRepository.existsByEmail(email)) {
             throw new IllegalStateException("이미 존재하는 이메일입니다.");
         }
-    }
-
-    private User findUserById(Long id) {
-        return userRepository.findById(id).orElseThrow(
-                () -> new IllegalStateException("존재하지 않는 회원입니다."));
     }
 }


### PR DESCRIPTION
## [완료사항]
### < 회원 API >
- 회원가입
- 로그인

### < 기타 >
- JWT를 이용한 인증/인가 필터 구현

- 정규식 적용
 1. 이메일 : `^[a-zA-Z0-9]+(.[_a-z0-9-]+)*@(?:\w+\.)+\w+$`
   - 영문자 및 숫자로 시작하고, 중간에 @를 포함하며, 한 단어로 이뤄진 최상위 도메인으로 끝나야 합니다.


 2. 비밀번호 : `^(?=.*[A-Za-z])(?=.*\d)(?=.*[@$!%*#?&])[A-Za-z\d@$!%*#?&]{8,}$`
   - 비밀번호는 영문자/숫자/특수문자 포함 8자리 이상이어야 합니다.

## 추후 추가 및 개선예정사항
- 주문, 가게에 대한 1:N 연관 관계 매핑