### PR TITLE
[Feature] 가게 입장에서 Cart를 다루는 Order 도메인 구현

### DIFF
--- a/src/main/java/com/example/baglemonster/cart/controller/OrderController.java
+++ b/src/main/java/com/example/baglemonster/cart/controller/OrderController.java
@@ -1,0 +1,51 @@
+package com.example.baglemonster.cart.controller;
+
+import com.example.baglemonster.cart.dto.OrderResponseDto;
+import com.example.baglemonster.cart.dto.OrdersResponseDto;
+import com.example.baglemonster.cart.service.OrderService;
+import com.example.baglemonster.common.dto.ApiResponseDto;
+import com.example.baglemonster.common.security.UserDetailsImpl;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+@Tag(name = "가게 주문 API", description = "가게의 전체/단일 주문 확인, 취소, 판매 완료와 관련된 API 정보를 담고 있습니다.")
+public class OrderController {
+
+    private final OrderService orderService;
+
+    @Operation(summary = "전체 주문 조회", description = "가게의 전체 주문내역을 조회합니다.")
+    @GetMapping("/stores/{storeId}/orders")
+    public ResponseEntity<OrdersResponseDto> selectOrders(@AuthenticationPrincipal UserDetailsImpl userDetails, @PathVariable Long storeId) {
+         OrdersResponseDto result = orderService.selectOrders(userDetails.getUser(), storeId);
+         return ResponseEntity.ok(result);
+    }
+
+    @Operation(summary = "단일 주문 조회", description = "가게의 특정 주문내역을 조회합니다.")
+    @GetMapping("/stores/{storeId}/orders/{orderId}")
+    public ResponseEntity<OrderResponseDto> selectOrder(@AuthenticationPrincipal UserDetailsImpl userDetails, @PathVariable Long storeId, @PathVariable Long orderId) {
+        OrderResponseDto result = orderService.selectOrder(userDetails.getUser(), storeId, orderId);
+        return ResponseEntity.ok(result);
+    }
+
+    @Operation(summary = "판매 완료", description = "판매가 완료된 주문의 상태를 판매됨으로 변경합니다.")
+    @PutMapping("/stores/{storeId}/orders/{orderId}")
+    public ResponseEntity<ApiResponseDto> completeOrder(@AuthenticationPrincipal UserDetailsImpl userDetails, @PathVariable Long storeId, @PathVariable Long orderId) {
+        orderService.completeOrder(userDetails.getUser(), storeId, orderId);
+        return ResponseEntity.ok().body(new ApiResponseDto(HttpStatus.OK.value(), "해당 주문이 판매되었습니다."));
+    }
+
+    @Operation(summary = "주문 취소", description = "재고 소진 등의 이유로 주문의 상태를 취소됨으로 변경합니다.")
+    @DeleteMapping("/stores/{storeId}/orders/{orderId}")
+    public ResponseEntity<ApiResponseDto> cancelOrder(@AuthenticationPrincipal UserDetailsImpl userDetails, @PathVariable Long storeId, @PathVariable Long orderId) {
+        orderService.cancelOrder(userDetails.getUser(), storeId, orderId);
+        return ResponseEntity.ok().body(new ApiResponseDto(HttpStatus.NO_CONTENT.value(), "해당 주문이 취소되었습니다."));
+    }
+}

--- a/src/main/java/com/example/baglemonster/cart/dto/CartRequestDto.java
+++ b/src/main/java/com/example/baglemonster/cart/dto/CartRequestDto.java
@@ -1,6 +1,7 @@
 package com.example.baglemonster.cart.dto;
 
 import com.example.baglemonster.cart.entity.Cart;
+import com.example.baglemonster.cart.entity.StoreStatusEnum;
 import com.example.baglemonster.cartProduct.entity.CartProduct;
 import com.example.baglemonster.product.entity.Product;
 import com.example.baglemonster.store.entity.Store;
@@ -20,6 +21,7 @@ public class CartRequestDto {
     public Cart toCart(User user, Store store) {
         return Cart.builder()
                 .status(false)
+                .storeStatus(StoreStatusEnum.NEWORDER)
                 .user(user)
                 .store(store)
                 .totalPrice(0)

--- a/src/main/java/com/example/baglemonster/cart/dto/OrderResponseDto.java
+++ b/src/main/java/com/example/baglemonster/cart/dto/OrderResponseDto.java
@@ -1,0 +1,38 @@
+package com.example.baglemonster.cart.dto;
+
+import com.example.baglemonster.cart.entity.Cart;
+import com.example.baglemonster.cartProduct.dto.CartProductResponseDto;
+import com.example.baglemonster.cartProduct.entity.CartProduct;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+public class OrderResponseDto {
+
+    private Long orderId;
+    private String storeName;
+    private List<CartProductResponseDto> products;
+    private Integer totalPrice;
+    private String request;
+    private String storeStatus;
+    private LocalDateTime createdDate;
+    private LocalDateTime modifiedDate;
+
+    public static OrderResponseDto of(Cart cart) {
+        List<CartProduct> cartProducts = cart.getCartProducts();
+        return OrderResponseDto.builder()
+                .orderId(cart.getId())
+                .storeName(cart.getStore().getName())
+                .products(cartProducts.stream().map(CartProductResponseDto::of).toList())
+                .totalPrice(cart.getTotalPrice())
+                .request(cart.getRequest())
+                .storeStatus(cart.getStoreStatus().getStatus())
+                .createdDate(cart.getCreatedDate())
+                .modifiedDate(cart.getModifiedDate())
+                .build();
+    }
+}

--- a/src/main/java/com/example/baglemonster/cart/dto/OrdersResponseDto.java
+++ b/src/main/java/com/example/baglemonster/cart/dto/OrdersResponseDto.java
@@ -1,0 +1,23 @@
+package com.example.baglemonster.cart.dto;
+
+import com.example.baglemonster.cart.entity.Cart;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class OrdersResponseDto {
+
+    private List<OrderResponseDto> orders;
+
+    public static OrdersResponseDto of(List<Cart> carts) {
+        List<OrderResponseDto> ordersResponseDto = carts.stream()
+                .map(OrderResponseDto::of).toList();
+
+        return OrdersResponseDto.builder()
+                .orders(ordersResponseDto)
+                .build();
+    }
+}

--- a/src/main/java/com/example/baglemonster/cart/entity/Cart.java
+++ b/src/main/java/com/example/baglemonster/cart/entity/Cart.java
@@ -32,6 +32,10 @@ public class Cart extends Timestamped {
     @Column(name = "status", nullable = false)
     private Boolean status;
 
+    @Column(nullable = false)
+    @Enumerated(value = EnumType.STRING)
+    private StoreStatusEnum storeStatus;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "userId", nullable = false)
     private User user;
@@ -51,5 +55,9 @@ public class Cart extends Timestamped {
     public void order(OrderRequestDto orderRequestDto) {
         this.request = orderRequestDto.getRequest();
         this.status = true;
+    }
+
+    public void editStoreStatus(StoreStatusEnum storeStatus) {
+        this.storeStatus = storeStatus;
     }
 }

--- a/src/main/java/com/example/baglemonster/cart/entity/StoreStatusEnum.java
+++ b/src/main/java/com/example/baglemonster/cart/entity/StoreStatusEnum.java
@@ -1,0 +1,23 @@
+package com.example.baglemonster.cart.entity;
+
+public enum StoreStatusEnum {
+    NEWORDER(Status.NEWORDER), READ(Status.READ), SOLD(Status.SOLD), CANCELED(Status.CANCELED);
+
+    private final String status;
+
+    StoreStatusEnum(String status) {
+        this.status = status;
+    }
+
+    public String getStatus() { return this.status; }
+
+    private static class Status {
+        public static final String NEWORDER = "NEWORDER";
+
+        public static final String READ = "READ";
+
+        public static final String SOLD = "SOLD";
+
+        public static final String CANCELED = "CANCELED";
+    }
+}

--- a/src/main/java/com/example/baglemonster/cart/repository/CartRepository.java
+++ b/src/main/java/com/example/baglemonster/cart/repository/CartRepository.java
@@ -1,6 +1,7 @@
 package com.example.baglemonster.cart.repository;
 
 import com.example.baglemonster.cart.entity.Cart;
+import com.example.baglemonster.cart.entity.StoreStatusEnum;
 import com.example.baglemonster.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -10,4 +11,6 @@ public interface CartRepository extends JpaRepository<Cart, Long> {
     Cart findByUserAndStatus(User user, boolean status);
 
     List<Cart> findAllByUser(User user);
+
+    List<Cart> findByStoreIdAndStatusAndStoreStatusIn(Long storeId, boolean b, List<StoreStatusEnum> neworder);
 }

--- a/src/main/java/com/example/baglemonster/cart/service/OrderService.java
+++ b/src/main/java/com/example/baglemonster/cart/service/OrderService.java
@@ -1,0 +1,74 @@
+package com.example.baglemonster.cart.service;
+
+import com.example.baglemonster.cart.dto.OrderResponseDto;
+import com.example.baglemonster.cart.dto.OrdersResponseDto;
+import com.example.baglemonster.cart.entity.Cart;
+import com.example.baglemonster.cart.entity.StoreStatusEnum;
+import com.example.baglemonster.cart.repository.CartRepository;
+import com.example.baglemonster.common.exception.NotFoundException;
+import com.example.baglemonster.common.exception.UnauthorizedException;
+import com.example.baglemonster.store.entity.Store;
+import com.example.baglemonster.store.repository.StoreRepository;
+import com.example.baglemonster.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class OrderService {
+
+    private final CartRepository cartRepository;
+    private final StoreRepository storeRepository;
+
+    @Transactional(readOnly = true)
+    public OrdersResponseDto selectOrders(User user, Long storeId) {
+        confirmStore(user, storeId);
+
+        return OrdersResponseDto.of(getOrders(storeId));
+    }
+
+    @Transactional
+    public OrderResponseDto selectOrder(User user, Long storeId, Long orderId) {
+        confirmStore(user, storeId);
+
+        Cart order = getOrder(orderId);
+        order.editStoreStatus(StoreStatusEnum.READ);
+
+        return OrderResponseDto.of(getOrder(orderId));
+    }
+
+    @Transactional
+    public void completeOrder(User user, Long storeId, Long orderId) {
+        confirmStore(user, storeId);
+        Cart order = getOrder(orderId);
+        order.editStoreStatus(StoreStatusEnum.SOLD);
+    }
+
+    @Transactional
+    public void cancelOrder(User user, Long storeId, Long orderId) {
+        confirmStore(user, storeId);
+        Cart order = getOrder(orderId);
+        order.editStoreStatus(StoreStatusEnum.CANCELED);
+    }
+
+    private void confirmStore(User user, Long storeId) {
+        Store store = storeRepository.findById(storeId).orElseThrow(() ->
+                new NotFoundException("선택한 가게는 존재하지 않습니다."));
+
+        if (!store.getUser().getId().equals(user.getId())) {
+            throw new UnauthorizedException("해당 가게에 대한 권한이 없습니다.");
+        }
+    }
+
+    private List<Cart> getOrders(Long storeId) {
+        return cartRepository.findByStoreIdAndStatusAndStoreStatusIn(storeId, true, List.of(StoreStatusEnum.NEWORDER, StoreStatusEnum.READ));
+    }
+
+    private Cart getOrder(Long orderId) {
+        return cartRepository.findById(orderId).orElseThrow(() ->
+                new NotFoundException("선택한 주문은 존재하지 않습니다."));
+    }
+}

--- a/src/main/java/com/example/baglemonster/user/entity/User.java
+++ b/src/main/java/com/example/baglemonster/user/entity/User.java
@@ -25,8 +25,4 @@ public class User {
     @Column(nullable = false)
     @Enumerated(value = EnumType.STRING)
     private UserRoleEnum role;
-
-//    @Builder.Default
-//    @OneToMany(mappedBy = "user")
-//    private List<Order> orders = new ArrayList<>();
 }


### PR DESCRIPTION
## 구현 사항
 - 기존 Cart 디렉토리에 소비자와 구별하기 위해 별도의 Order 엔티티, DTO, 컨트롤러, 서비스 생성
 - Cart 엔티티에 가게의 주문 상태를 보기 위한 Enum 클래스 추가 `NEWORDER, READ, SOLD, CANCELED`
   - `NEWORDER` : 소비자가 최초 장바구니 생성 시
   - `READ` : 가게가 NEWORDER 상태의 주문을 단일 조회할 시
   - `SOLD` : 상품 판매가 완료되었을 시
   - `CANCELED` : 가게가 주문 취소할 시

- 가게가 주문 전체 조회 시, 가게 상태가 'NEWORDER'와 'READ'인 주문만 가져오도록 JPA의 In 키워드 사용
```
  // CartRepository.java 
  ...

      List<Cart> findByStoreIdAndStatusAndStoreStatusIn(Long storeId, boolean b, List<StoreStatusEnum> neworder);

  ...
```

## 수정할 점
 - 소비자 주문 완료 시가 아니라 가게가 판매 완료 시 해당 상품의 인기도를 주문량 만큼 추가하기