### PR TITLE
[Feature] 가게 단일 조회에 Redis 캐싱 기능 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ build/
 !**/src/test/**/build/
 application-ds.properties
 application-s3.properties
+application-redis.properties
 
 ### STS ###
 .apt_generated

--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,9 @@ repositories {
 }
 
 dependencies {
+    // Redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
     // swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
 

--- a/src/main/java/com/example/baglemonster/common/config/RedisRepositoryConfig.java
+++ b/src/main/java/com/example/baglemonster/common/config/RedisRepositoryConfig.java
@@ -1,0 +1,51 @@
+package com.example.baglemonster.common.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@EnableRedisRepositories(basePackages = "com.example.baglemonster.common.config")
+public class RedisRepositoryConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String redisHost;
+
+    @Value("${spring.data.redis.port}")
+    private int redisPort;
+
+    // jackson LocalDateTime mapper
+    @Bean
+    public ObjectMapper objectMapper() {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS); // timestamp 형식 안따르도록 설정
+        mapper.registerModules(new JavaTimeModule(), new Jdk8Module()); // LocalDateTime 매핑을 위해 모듈 활성화
+        return mapper;
+    }
+
+    // redisConnectionFactory 를 통해 외부 redis 를 연결합니다.
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(redisHost, redisPort);
+    }
+
+    //RedisTemplate을 통해 RedisConnection에서 넘겨준 byte 값을 객체 직렬화합니다.
+    @Bean
+    public RedisTemplate<?, ?> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer(objectMapper()));
+        return redisTemplate;
+    }
+}

--- a/src/main/java/com/example/baglemonster/product/service/ProductService.java
+++ b/src/main/java/com/example/baglemonster/product/service/ProductService.java
@@ -81,7 +81,8 @@ public class ProductService {
         String currentPictureUrl = product.getProductPictureUrl();
         String productPictureUrl = currentPictureUrl;
         if (file != null) {
-            s3UploadService.deleteFile(currentPictureUrl);
+            if(currentPictureUrl != null)
+                s3UploadService.deleteFile(currentPictureUrl);
             productPictureUrl  = s3UploadService.uploadFile(file);
         }
 

--- a/src/main/java/com/example/baglemonster/store/service/StoreService.java
+++ b/src/main/java/com/example/baglemonster/store/service/StoreService.java
@@ -48,7 +48,7 @@ public class StoreService {
         StoreResponseDto result = null;
         String key = "storeIdx::" + storeId;
 
-        if (Boolean.TRUE.equals(redisTemplate.hasKey(key))){
+        if (Boolean.TRUE.equals(redisTemplate.hasKey(key))) {
             result = getRedisStore(key);
         } else {
             Store store = findStore(storeId);
@@ -98,6 +98,11 @@ public class StoreService {
 
         if (!store.getUser().getId().equals(user.getId())) {
             throw new UnauthorizedException("가게 수정에 대한 권한이 없습니다.");
+        }
+
+        String key = "storeIdx::" + storeId;
+        if (Boolean.TRUE.equals(redisTemplate.hasKey(key))) {
+            redisTemplate.delete(key);
         }
 
         String currentPictureUrl = store.getStorePictureUrl();

--- a/src/main/java/com/example/baglemonster/store/service/StoreService.java
+++ b/src/main/java/com/example/baglemonster/store/service/StoreService.java
@@ -100,19 +100,17 @@ public class StoreService {
             throw new UnauthorizedException("가게 수정에 대한 권한이 없습니다.");
         }
 
-        String key = "storeIdx::" + storeId;
-        if (Boolean.TRUE.equals(redisTemplate.hasKey(key))) {
-            redisTemplate.delete(key);
-        }
-
         String currentPictureUrl = store.getStorePictureUrl();
         String storePictureUrl = currentPictureUrl;
         if (file != null) {
-            s3UploadService.deleteFile(currentPictureUrl);
+            if(currentPictureUrl != null)
+                s3UploadService.deleteFile(currentPictureUrl);
             storePictureUrl = s3UploadService.uploadFile(file);
         }
 
         store.editStore(storeRequestDto, storePictureUrl);
+
+        deleteRedisStore(storeId);
     }
 
     // 가게 삭제
@@ -165,5 +163,12 @@ public class StoreService {
     private void setRedisStore(String key, StoreResponseDto result) {
         ValueOperations<String, StoreResponseDto> valueOperations = redisTemplate.opsForValue();
         valueOperations.set(key, result, 20, TimeUnit.SECONDS);
+    }
+
+    private void deleteRedisStore(Long storeId) {
+        String key = "storeIdx::" + storeId;
+        if (Boolean.TRUE.equals(redisTemplate.hasKey(key))) {
+            redisTemplate.delete(key);
+        }
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,4 +1,4 @@
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.jpa.hibernate.ddl-auto=update
 
-spring.profiles.include=ds, s3
+spring.profiles.include=ds, s3, redis


### PR DESCRIPTION
## 목표한 점
 1. 데이터 캐싱을 통한 정보 조회 속도 향상
 2. 빈번하고 동일한 요청으로 인한 DB 부하 감소

## 변경된 점
 1. redis 의존성 추가
 2. 가게 단일 조회 기능 최초 수행 시 MySQL에서 가져온 DTO로 변환 후 Redis에 캐싱
 3. 가게 수정 및 상품 등록/수정/삭제 수행 후 redis에 저장된 dto 삭제 로직 추가

## 결과
 - 조건: 상품 25개가 등록된 단일 가게에 대해 1000번 요청 수행
 - 결과: MySQL 단일과 Redis 적용 시 서로 **_미세한 차이점_** 밖에 보이지 않았음
 1. MySQL : 수행 시간(1m 40s), 평균 응답 시간(**_12ms_**)
 
![mysql_running_result](https://github.com/proLmpa/BagleMonster_BE/assets/52267654/a7cd1f1d-e9b7-4f26-8385-e7a302b7dfa1)

 2. Redis : 수행 시간(1m45s), 평균 응답 시간(**_11ms_**)
 
![redis_running_result](https://github.com/proLmpa/BagleMonster_BE/assets/52267654/49ad75f5-a223-4387-ba02-8554c8898e79)

* 결과 분석
 - 등록된 상품의 수가 턱없이 적어 데이터 조회 성능 차이를 비교할 수 없었음.
 - MySQL의 프로시저 등을 이용해 mock 데이터를 최소 수천 개 이상 등록할 필요성 대두 (추가 진행 사항)
